### PR TITLE
Validate through JSHint and fixes problem with multiple event bindings

### DIFF
--- a/fullscreen/jquery.fullscreen.js
+++ b/fullscreen/jquery.fullscreen.js
@@ -44,6 +44,7 @@
 		} else if (document.webkitCancelFullScreen) {
 			document.webkitCancelFullScreen();
 		}
+		$(document).off( 'fullscreenchange mozfullscreenchange webkitfullscreenchange' );
 	}
 
 	function onFullScreenEvent(callback){


### PR DESCRIPTION
Hey,

In case you are interested, I've a few fixes.

The first is to validate through JSHint (mostly moves a few functions) and adds the function $.fn.cancelFullScreen.
The second fixes a minor error I made in the first
And the third fixes an issue with the fullscreenchange event, if the fullscreen mode was started more than once the fullscreenchange-event from each of the previous fullscreen modes were trigger too. This unbinds the event on exit of the fullscreen mode
