### PR TITLE
event handler was never called after manual cancelFullScreen

### DIFF
--- a/fullscreen/jquery.fullscreen.js
+++ b/fullscreen/jquery.fullscreen.js
@@ -44,7 +44,6 @@
 		} else if (document.webkitCancelFullScreen) {
 			document.webkitCancelFullScreen();
 		}
-		$(document).off( 'fullscreenchange mozfullscreenchange webkitfullscreenchange' );
 	}
 
 	function onFullScreenEvent(callback){
@@ -122,6 +121,8 @@
 		onFullScreenEvent(function(fullScreen){
 			if(!fullScreen){
 				// We have exited full screen.
+			        // Detach event listener
+			        $(document).off( 'fullscreenchange mozfullscreenchange webkitfullscreenchange' );
 				// Remove the class and destroy
 				// the temporary div
 


### PR DESCRIPTION
The event listener was removed too soon, the event handler was not
called after cancelFullScreen.
