### PR TITLE
I fixed a problem where keyboard input was disabled in fullscreen in Webkit

### DIFF
--- a/fullscreen/jquery.fullscreen.js
+++ b/fullscreen/jquery.fullscreen.js
@@ -25,7 +25,7 @@
 		} else if (elem.mozRequestFullScreen) {
 			elem.mozRequestFullScreen();
 		} else if (elem.webkitRequestFullScreen) {
-			elem.webkitRequestFullScreen();
+			elem.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
 		}
 	}
 


### PR DESCRIPTION
I discovered the source of this problem here:

https://github.com/marijnh/CodeMirror/issues/733

It's apparently not a bug, but a feature. Is it perhaps a security feature, to help prevent phishing attacks, by making it slightly more cumbersome to do something like create a fake Windows login screen? Who knows. Since it's such a terrible feature, it's been filed as a bug below, but as of writing is currently untriaged:

https://code.google.com/p/chromium/issues/detail?id=143676&q=fullscreen&colspec=ID%20Pri%20Mstone%20ReleaseBlock%20OS%20Area%20Feature%20Status%20Owner%20Summary&rlz=1Y1XIUG_enGB514GB514
