### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ You can then apply additional styles to your element. Take the opportunity to in
 
 ```css
 
-#content.fullScreen{
+# content.fullScreen{
 	/* Give the element a width and margin:0 auto; to center it. */
 }
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
